### PR TITLE
fix: unmount modal root when navigating to different layout

### DIFF
--- a/js/modal.js
+++ b/js/modal.js
@@ -1,10 +1,14 @@
-import { defineComponent } from 'vue'
-import { useModal } from './useModal'
+import { defineComponent } from "vue";
+import { useModal } from "./useModal";
 
 export const Modal = defineComponent({
   setup() {
-    const { vnode } = useModal()
+    const { vnode, close } = useModal();
 
-    return () => vnode.value
+    onBeforeUnmount(() => {
+      close();
+    });
+
+    return () => vnode.value;
   },
-})
+});


### PR DESCRIPTION
When a modal gets redirected to a new page that uses a different layout, the modal root stays mounted, and stays on top of the entire page, and renders the page unusable (even though it's invisible).

This happens even if the new layout also implements the <Modal /> component.