### PR TITLE
fix: base url is duplicated when using a custom subdirectory

### DIFF
--- a/src/Modal.php
+++ b/src/Modal.php
@@ -133,9 +133,10 @@ class Modal implements Responsable
             'modal' => $this->component(),
         ];
 
+        $request = request();
         $page = [
             'props' => $props,
-            'url' => request()->getBaseUrl().request()->getRequestUri(),
+            'url' => Str::start(Str::after($request->fullUrl(), $request->getSchemeAndHttpHost()), '/'),
             'version' => Inertia::getVersion(),
         ];
 


### PR DESCRIPTION
There was a long-standing bug in inertia that the base URL was duplicated in the Response "url" property. This issue arose when the app was hosted under https://my.domain/subdirectory and caused URLs to be set to  https://my.domain/subdirectory/subdirectory.

The issue was fixed upstream in https://github.com/inertiajs/inertia-laravel/pull/592 and I am proposing to apply the same fix here.

Thank you for this amazing package!