### PR TITLE
Inertia 2.0 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "require": {
         "php": "^8.0",
         "illuminate/support": "^8.24|^9.0|^10.0|^11.0",
-        "inertiajs/inertia-laravel": "^0.6.9|^1.0.0"
+        "inertiajs/inertia-laravel": "^0.6.9|^1.0.0|^2.0"
     },
     "require-dev": {
         "larastan/larastan": "^2.9.2",

--- a/dist/inertia-modal.js
+++ b/dist/inertia-modal.js
@@ -20,6 +20,7 @@ function preserveBackdrop () {
     if (response.headers['x-inertia-modal']) {
       let { component, props } = usePage();
       props = JSON.parse(JSON.stringify(props));
+      response.data = typeof response.data === 'string' ? JSON.parse(response.data) : response.data;
       response.data.props = { ...props, ...response.data.props };
       response.data.component = component;
       response.headers['x-inertia'] = true;

--- a/dist/inertia-modal.umd.js
+++ b/dist/inertia-modal.umd.js
@@ -22,6 +22,7 @@
       if (response.headers['x-inertia-modal']) {
         let { component, props } = vue3.usePage();
         props = JSON.parse(JSON.stringify(props));
+        response.data = typeof response.data === 'string' ? JSON.parse(response.data) : response.data;
         response.data.props = { ...props, ...response.data.props };
         response.data.component = component;
         response.headers['x-inertia'] = true;

--- a/js/preserveBackdrop.js
+++ b/js/preserveBackdrop.js
@@ -10,6 +10,7 @@ export default function () {
     if (response.headers['x-inertia-modal']) {
       let { component, props } = usePage();
       props = JSON.parse(JSON.stringify(props));
+      response.data = typeof response.data === 'string' ? JSON.parse(response.data) : response.data;
       response.data.props = { ...props, ...response.data.props };
       response.data.component = component;
       response.headers['x-inertia'] = true


### PR DESCRIPTION
I'm opening this PR to get the ball rolling on Inertia 2.0 support and sharing my findings while attempting to upgrade a project (#39).

Inertia 2.0 appears to break `preserveBackdrop.js`, due to axios' `response.data` coming in as a string. Might have something to do History Encryption introduced in Inertia 2.0 and changes in the way response data is sent down to the frontend. This PR resolves that by conditionally parsing the response data from string if needed.

I'm unsure how to write a formal test for this. It would be great to get a second opinion on this and whether this PR is on the right track.