### PR TITLE
Update Modal.php

### DIFF
--- a/src/Modal.php
+++ b/src/Modal.php
@@ -248,4 +248,9 @@ class Modal implements Responsable
 
         return $response;
     }
+
+    public function getProps(): array
+    {
+        return $this->props;
+    }
 }


### PR DESCRIPTION
Added getProps helper method to Modal class.

This was needed for a very specific testing case, but I thought I'd submit the pull and you can decide if it's useful for you or not.

During my unit tests I wanted to examine the modal props property without rendering a full response object.