### PR TITLE
Avoid deep cloning backdrop props

### DIFF
--- a/dist/inertia-modal.js
+++ b/dist/inertia-modal.js
@@ -1,4 +1,4 @@
-import { ref, computed, shallowRef, watch, defineAsyncComponent, h, nextTick, defineComponent } from 'vue';
+import { ref, toRaw, computed, shallowRef, watch, defineAsyncComponent, h, nextTick, defineComponent } from 'vue';
 import { http, usePage, router } from '@inertiajs/vue3';
 
 const resolveCallback = ref();
@@ -16,7 +16,7 @@ const mergePageData = (currentValue, responseValue) => {
   }
 
   return {
-    ...JSON.parse(JSON.stringify(currentValue || {})),
+    ...toRaw(currentValue || {}),
     ...(responseValue || {}),
   }
 };
@@ -34,7 +34,7 @@ function preserveBackdrop (app) {
 
       response.data.component = currentPage.component;
       response.data.props = {
-        ...JSON.parse(JSON.stringify(currentPage.props)),
+        ...toRaw(currentPage.props),
         ...response.data.props
       };
 

--- a/js/preserveBackdrop.js
+++ b/js/preserveBackdrop.js
@@ -1,4 +1,5 @@
 import { http } from '@inertiajs/vue3'
+import { toRaw } from 'vue'
 
 const mergePageData = (currentValue, responseValue) => {
   if (Array.isArray(currentValue) || Array.isArray(responseValue)) {
@@ -6,7 +7,7 @@ const mergePageData = (currentValue, responseValue) => {
   }
 
   return {
-    ...JSON.parse(JSON.stringify(currentValue || {})),
+    ...toRaw(currentValue || {}),
     ...(responseValue || {}),
   }
 }
@@ -24,7 +25,7 @@ export default function (app) {
 
       response.data.component = currentPage.component
       response.data.props = {
-        ...JSON.parse(JSON.stringify(currentPage.props)),
+        ...toRaw(currentPage.props),
         ...response.data.props
       }
 


### PR DESCRIPTION
## Summary

This PR avoids synchronously deep-cloning the current Inertia page props when preserving the modal backdrop. Instead of serializing the whole page prop tree with `JSON.parse(JSON.stringify(...))`, the modal response now uses Vue's `toRaw()` and a shallow spread for the existing backdrop props.

## Why

The current implementation deep-clones `currentPage.props` every time an `X-Inertia-Modal` response is handled. On large Inertia pages, opening a small modal can therefore force the browser main thread to walk, stringify, parse, and allocate a full copy of the entire backdrop page payload before the modal can render.

That cost scales with the size of the page behind the modal, not with the modal itself. In applications with large table/list/detail props, timelines, nested resources, or many records, this can show up as long tasks or intermittent UI freezes when opening modal pages.

This change keeps the existing top-level merge behavior while removing the expensive JSON serialization step. It turns backdrop preservation from a deep O(total nested prop payload) clone into a shallow top-level merge, which should significantly reduce main-thread work and memory churn for large pages.

## Notes

- `toRaw()` unwraps Vue's reactive proxy so the spread works with the underlying page props object.
- The merge still creates a new top-level `props` object and lets modal response props override backdrop props.
- Nested objects are no longer duplicated, which matches the preservation use case: the backdrop page state is being reused, not mutated by the modal package.
- The same change is applied to preserved page metadata in `mergePageData()`.

## Validation

- Ran `npm install`
- Ran `npm run build` to regenerate `dist/inertia-modal.js`
- `npm test` is not available in this package (`Missing script: "test"`)
